### PR TITLE
fix/auth-validation

### DIFF
--- a/src/Redux/auth/auth-slice.js
+++ b/src/Redux/auth/auth-slice.js
@@ -12,6 +12,11 @@ const initialState = {
 export const authSlice = createSlice({
   name: 'auth',
   initialState,
+  reducers: {
+    resetHttpError: (state) => {
+      state.error = null;
+    },
+  },
   extraReducers: (builder) => {
     // register
     builder.addCase(register.pending, (state, action) => {

--- a/src/components/AuthForm/AuthForm.jsx
+++ b/src/components/AuthForm/AuthForm.jsx
@@ -10,10 +10,11 @@ import AuthButton from '../AuthComponents/AuthButton';
 import AuthFooter from '../AuthComponents/AuthFooter';
 import AuthLabel from '../AuthComponents/AuthLabel';
 import AuthWrapper from '../AuthComponents/AuthWrapper';
+import { authSlice } from '../../Redux/auth/auth-slice';
 
 const AuthForm = () => {
   const dispatch = useDispatch();
-  let httpError = useSelector(getAuthError);
+  const httpError = useSelector(getAuthError);
 
   const formik = useFormik({
     initialValues: {
@@ -22,13 +23,18 @@ const AuthForm = () => {
       password: '',
       confirmPassword: '',
     },
+
+    validate: (values) => {
+      //reset httpError before press button. Fix stack messages
+      dispatch(authSlice.actions.resetHttpError());
+    },
+
     validateOnChange: false,
     validateOnBlur: false,
 
     validationSchema: AuthFormSchema,
 
     onSubmit: ({ name, email, password }, { resetForm }) => {
-      httpError = null;
       dispatch(register({ name, email, password }));
       resetForm();
     },

--- a/src/components/LoginForm/LoginForm.jsx
+++ b/src/components/LoginForm/LoginForm.jsx
@@ -10,24 +10,30 @@ import AuthButton from '../AuthComponents/AuthButton';
 import AuthFooter from '../AuthComponents/AuthFooter';
 import AuthLabel from '../AuthComponents/AuthLabel';
 import AuthWrapper from '../AuthComponents/AuthWrapper';
+import { authSlice } from '../../Redux/auth/auth-slice';
 
 const LoginForm = () => {
   const [passwordVisible, setPasswordVisible] = useState(false);
   const dispatch = useDispatch();
-  let httpError = useSelector(getAuthError);
+  const httpError = useSelector(getAuthError);
 
   const formik = useFormik({
     initialValues: {
       email: '',
       password: '',
     },
+
+    validate: (values) => {
+      //reset httpError before press button. Fix stack messages
+      dispatch(authSlice.actions.resetHttpError());
+    },
+
     validateOnChange: false,
     validateOnBlur: false,
 
     validationSchema: LoginFormSchema,
 
     onSubmit: ({ email, password }, { resetForm }) => {
-      httpError = null;
       dispatch(login({ email, password }));
       resetForm();
     },


### PR DESCRIPTION
fix when messages stack on each other
Old bug: First, need to call a error from axios, "Email in use" or "Password or Email is incorrect". When you press the button, messages were stack.
Fix: remove http errors before press button, add reducer which clear state.error